### PR TITLE
Group automated PRs into their own section (optin)

### DIFF
--- a/bin/review-rot
+++ b/bin/review-rot
@@ -51,6 +51,29 @@ def _get_token(item):
     return token
 
 
+def is_automated_pr(user):
+    """ 
+    Check if the user is a known automation bot.
+    
+    Args:
+        user (str): Username to check
+        
+    Returns:
+        bool: True if the user is an automated bot, False otherwise
+    """
+    automated_bots = [
+        'renovate[bot]',
+        'dependabot[bot]',
+        'red-hat-konflux[bot]',
+    ]
+    
+    if not user:
+        return False
+        
+    user_lower = user.lower()
+    return any(bot.lower() in user_lower for bot in automated_bots)
+
+
 def main():
     """
     Reads arguments from CLI and configuration file.
@@ -130,6 +153,11 @@ def main():
 
     if arguments.get('ignore_wip'):
         results = remove_wip(results)
+
+    # Mark reviews as automated if categorize_automated is enabled
+    if arguments.get('categorize_automated'):
+        for result in results:
+            result.is_automated = is_automated_pr(result.user)
 
     # With the --sort argument, --comment-sort is kept for backwards
     # compatibility. Equivalent to --sort commented

--- a/docs/index.html
+++ b/docs/index.html
@@ -22,6 +22,11 @@
 				<!-- site.js populates this div with the reviews. -->
 			</div>
 			<hr/>
+			<h2 id="automated-header" class="hidden">Automated Pull Requests</h2>
+			<div id="automated-reviews">
+				<!-- site.js populates this div with the automated reviews. -->
+			</div>
+			<hr/>
 			<h2 id="wip-header" class="hidden">Work In Progress Reviews</h2>
 			<div id="wip-reviews">
 				<!-- site.js populates this div with the WIP reviews. -->

--- a/docs/js/site.js
+++ b/docs/js/site.js
@@ -7,6 +7,7 @@ var average_age = function(requests) {
 		cls: 'default'
 	}
 }
+
 $(document).ready(function() {
 	var entry_template = Handlebars.compile($("#entry-template").html());
 	var stats_template = Handlebars.compile($("#stats-template").html());
@@ -34,11 +35,15 @@ $(document).ready(function() {
 				if (value.updated_time) {
 					value.relative_updated_time = moment.unix(value.updated_time).fromNow();
 				}
-				if (value.title.toUpperCase().indexOf("WIP") == -1) {
-					$('#reviews').append(entry_template(value));
-				} else {
+				
+				if (value.is_automated) {
+					$('#automated-header').removeClass('hidden');
+					$('#automated-reviews').append(entry_template(value));
+				} else if (value.title.toUpperCase().indexOf("WIP") != -1) {
 					$('#wip-header').removeClass('hidden');
 					$('#wip-reviews').append(entry_template(value));
+				} else {
+					$('#reviews').append(entry_template(value));
 				}
 			});
 			$('.page-header').append(stats_template(average_age(data)));

--- a/examples/sampleinput_new_format.yaml
+++ b/examples/sampleinput_new_format.yaml
@@ -29,6 +29,7 @@ git_services:
 arguments: 
   format: json
   reverse: true
+  categorize_automated: true
   ssl_verfiy: false
   debug: true
   cacert: ~/cacert_location

--- a/reviewrot/__init__.py
+++ b/reviewrot/__init__.py
@@ -110,6 +110,9 @@ def get_arguments(cli_arguments, config):
     if config_arguments.get("reverse"):
         parsed_arguments["reverse"] = True
 
+    if config_arguments.get("categorize_automated"):
+        parsed_arguments["categorize_automated"] = True
+
     email_in_config = config_arguments.get("email")
     if email_in_config:
         parsed_arguments["email"] = [
@@ -304,6 +307,11 @@ def parse_cli_args(args):
     )
     parser.add_argument(
         "--ignore-wip", help="Omit WIP PRs/MRs from output", action="store_true"
+    )
+    parser.add_argument(
+        "--categorize-automated", 
+        help="Mark automated PRs/MRs in JSON output for better categorization", 
+        action="store_true"
     )
     ssl_group = parser.add_argument_group("SSL")
     ssl_group.add_argument(

--- a/reviewrot/basereview.py
+++ b/reviewrot/basereview.py
@@ -147,6 +147,7 @@ class BaseReview(object):
         last_comment=None,
         project_name=None,
         project_url=None,
+        is_automated=False,
     ):
         """Initialization dunder."""
         self.user = user
@@ -159,6 +160,7 @@ class BaseReview(object):
         self.last_comment = last_comment
         self.project_name = project_name
         self.project_url = project_url
+        self.is_automated = is_automated
 
     @staticmethod
     def format_duration(created_at):
@@ -347,6 +349,7 @@ class BaseReview(object):
             "comments": self.comments,
             "type": type(self).__name__,
             "image": self.image,
+            "is_automated": self.is_automated,
         }
         if self.last_comment:
             data["last_comment"] = {


### PR DESCRIPTION
This commit adds a new input param called 'categorize_automated' that, if set to true, groups the PRs generated by bots like renovate or dependabot into their own section in the review rot page.


Assisted by: Cursor (powered by Claude 4 Sonnet)