### PR TITLE
Bump SLSA provenance job image in build pipeline

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -83,7 +83,7 @@ jobs:
       id-token: write # for creating OIDC tokens for signing.
       packages: write # for uploading attestations.
     if: ${{ github.ref == 'refs/heads/main' }}
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.4.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
     with:
       image: ${{ needs.build.outputs.image }}
       digest: ${{ needs.build.outputs.digest }}

--- a/README.md
+++ b/README.md
@@ -220,6 +220,6 @@ To verify the image SLSA Provenance attestation:
 cosign verify-attestation quay.io/lucarval/review-rot:latest \
   --type slsaprovenance \
   --certificate-github-workflow-repository lcarva/review-rot \
-  --certificate-identity 'https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@refs/tags/v1.4.0' \
+  --certificate-identity 'https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@refs/tags/v2.1.0' \
   --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
 ```


### PR DESCRIPTION
This should solve the error seen in the last build pipeline: 'error updating to TUF remote mirror: invalid key'.

Assisted by: Cursor (powered by Claude 4 Sonnet)

Ref: https://github.com/slsa-framework/slsa-github-generator/issues/3350