### PR TITLE
feat: display size labels for GitHub PRs

### DIFF
--- a/docs/css/site.css
+++ b/docs/css/site.css
@@ -46,3 +46,13 @@ a {
 .tab-pane {
     min-height: 200px;
 }
+
+/* Labels styling */
+.labels {
+  margin: 5px 0;
+}
+
+.labels .label {
+  margin-right: 3px;
+  font-size: 0.8em;
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -64,6 +64,13 @@
 				<a href="{{url}}" target="_blank"><h4 class="media-heading">{{title}}</h4></a>
 				Submitted {{relative_time}} ago by <b>@{{user}}</b>, with {{comments}} comments.<br />
 				{{#if relative_updated_time}}Updated {{relative_updated_time}}<br />{{/if}}
+				{{#if labels}}
+					<div class="labels">
+						{{#each labels}}
+							<span class="label label-info">{{this}}</span>
+						{{/each}}
+					</div>
+				{{/if}}
 				<a href="{{ repo_url }}" target="_blank" class="label label-default">{{pretty_repo}}</a>
 			</div>
 		</div>

--- a/reviewrot/basereview.py
+++ b/reviewrot/basereview.py
@@ -149,6 +149,7 @@ class BaseReview(object):
         project_name=None,
         project_url=None,
         is_automated=False,
+        labels=None,
     ):
         """Initialization dunder."""
         self.user = user
@@ -162,6 +163,7 @@ class BaseReview(object):
         self.project_name = project_name
         self.project_url = project_url
         self.is_automated = is_automated
+        self.labels = labels or []
 
     @staticmethod
     def format_duration(created_at):
@@ -353,6 +355,7 @@ class BaseReview(object):
             "type": type(self).__name__,
             "image": self.image,
             "is_automated": self.is_automated,
+            "labels": self.labels,
         }
         if self.last_comment:
             data["last_comment"] = {

--- a/reviewrot/githubstack.py
+++ b/reviewrot/githubstack.py
@@ -175,6 +175,7 @@ class GithubService(BaseService):
                 last_comment=last_comment,
                 project_name=repo.full_name,
                 project_url=repo.html_url,
+                labels=[label.name for label in pr.labels if label.name in ['XS', 'S', 'M', 'L', 'XL', 'XXL']],
             )
             log.debug(res)
             res_.append(res)


### PR DESCRIPTION
* Add support for showing only size-related labels (XS, S, M, L, XL, XXL) on GitHub pull requests in the review-rot web UI.

resolves: EC-1486